### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -4,6 +4,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/reach2sayan/Einstein_Summation/security/code-scanning/2](https://github.com/reach2sayan/Einstein_Summation/security/code-scanning/2)

To fix this issue, the workflow should have its permissions explicitly limited by adding a `permissions` block. This can be placed at the workflow root, to apply to all jobs, or at the job level, to apply to the specific build job. Since the workflow only requires standard read access (for actions like checking out code and caching), the minimal secure setting is `permissions: contents: read`. This should be added as close to the top as possible, ideally after the `name:` and `on:` blocks but before `jobs:`, to set the least privilege permissions globally for the workflow. No new methods, imports, or variable definitions are needed—just the addition of the proper YAML block in the `.github/workflows/action.yml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
